### PR TITLE
[BIOMAGE-2381] Fixed metadata new dropdown, and folded louvain clusters

### DIFF
--- a/e2e/cypress/integration/ui-smoke/ui-launch-analysis.spec.js
+++ b/e2e/cypress/integration/ui-smoke/ui-launch-analysis.spec.js
@@ -77,6 +77,7 @@ describe('Launches analysis successfully', () => {
 
     const numOfClusters = 5;
     // each cluster is duplicated so we multiply by 2
+    cy.get(':nth-child(1) > .ant-tree-switcher > .anticon > svg').click();
     cy.get('div > div > div > div > span:contains("Cluster")').should('have.length', numOfClusters * 2);
 
     cy.contains(/(We're getting your data|This will take a few minutes)/).should('exist');

--- a/e2e/cypress/support/commands.js
+++ b/e2e/cypress/support/commands.js
@@ -67,6 +67,7 @@ Cypress.Commands.add('addMetadata', () => {
   cy.log('Adding metadata track.');
 
   cy.contains('button', 'Add metadata').click();
+  cy.contains('Create track').click();
   cy.contains('.ant-popover', 'Provide new metadata track name').find('.anticon-check').click();
 });
 


### PR DESCRIPTION
Added
* Clicking the "Create track" inside the "Add metadata" dropdown
* Unfolding the louvain clusters before checking the # of clusters

# Background
#### Link to issue 
https://biomage.atlassian.net/browse/BIOMAGE-2381

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-org/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-org/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-org/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
