### PR TITLE
Allow for variability in the amoiunt of clusters

### DIFF
--- a/e2e/cypress/integration/ui-smoke/ui-launch-analysis.spec.js
+++ b/e2e/cypress/integration/ui-smoke/ui-launch-analysis.spec.js
@@ -75,10 +75,14 @@ describe('Launches analysis successfully', () => {
     cy.contains('.data-test-page-header', 'Data Exploration', { timeout: 60 * 1000 }).should('exist');
     cy.log('checking the number of louvain clusters in the tree');
 
-    const numOfClusters = 5;
-    // each cluster is duplicated so we multiply by 2
+    // numOfClusters depends on some random variables, so if the expected and returned values
+    // differ by 1 it should be fine
+    const numClustersOptions = [5, 6];
     cy.get(':nth-child(1) > .ant-tree-switcher > .anticon > svg').click();
-    cy.get('div > div > div > div > span:contains("Cluster")').should('have.length', numOfClusters * 2);
+    // each cluster is duplicated so we multiply by 2
+    cy.get('div > div > div > div > span:contains("Cluster")')
+      .its('length')
+      .should('be.oneOf', numClustersOptions.map((numClusters) => numClusters * 2))
 
     cy.contains(/(We're getting your data|This will take a few minutes)/).should('exist');
     cy.contains(/(We're getting your data|This will take a few minutes)/, { timeout: explorationTimeout }).should('not.exist');


### PR DESCRIPTION
# Background
Due to some random variables in the worker, the clusters in the test experiment are sometimes 6 instead of 5, which breaks the integration tests.

This pull request allows for either 5 or 6 clusters to show up.

#### Link to issue 
N/A

#### Link to staging deployment URL 

#### Links to any Pull Requests related to this

#### Anything else the reviewers should know about the changes here

# Changes
### Code changes

# Definition of DONE
Your changes will be ready for merging after each of the steps below have been completed:

### Testing
- [ ] Unit tests written
- [ ] Tested locally with Inframock (with latest production data downloaded with biomage experiment pull)
- [ ] Deployed to staging

To set up easy local testing with inframock, follow the instructions here: https://github.com/biomage-org/inframock
To deploy to the staging environment, follow the instructions here: https://github.com/biomage-org/biomage-utils

### Documentation updates
Is all relevant documentation updated to reflect the proposed changes in this PR?

- [ ] Relevant Github READMEs updated
- [ ] Relevant wiki pages created/updated

### Approvers
- [ ] Approved by a member of the core engineering team
- [ ] (UX changes) Approved by vickymorrison (this is her username, tag her if you need approval)

### Just before merging:
- [ ] After the PR is approved, the `unstage` script in here: https://github.com/biomage-org/biomage-utils is executed. This script cleans up your deployment to staging

### Optional
- [ ] Photo of a cute animal attached to this PR
